### PR TITLE
Added a space before stdout redirection at browserstack-local call.

### DIFF
--- a/lib/Local.php
+++ b/lib/Local.php
@@ -118,7 +118,7 @@ class Local {
       system('echo "" > '. '$this->logfile');
     else
       system("echo \"\" > '$this->logfile' ");
-    $call = $call . "2>&1";
+    $call = $call . " 2>&1";
     $return_message = shell_exec($call);
     $data = json_decode($return_message,true);
     if ($data["state"] != "connected") {


### PR DESCRIPTION
Normally when we pass to the start function parameters as for example '-parallel-runs', the function add_args append it to the string $call. Before execute the call the stderr to stdout redirection is appended to the string ( see line 121 in Local.php ). 
If some custom parameters are passed to the start method, the value of the last custom parameter is sticked with the string "2>&1" in $call variable and this cause an exception.
Adding a space avoid this exception in this case. 