### PR TITLE
Remove deprecated single dash options for BrowserStackLocal binary

### DIFF
--- a/lib/Local.php
+++ b/lib/Local.php
@@ -73,25 +73,25 @@ class Local {
     elseif ($arg_key == "v")
       $this->verbose_flag = "-vvv";
     elseif ($arg_key == "force")
-      $this->force_flag = "-force";
+      $this->force_flag = "--force";
     elseif ($arg_key == "only")
-      $this->only_flag = "-only";
+      $this->only_flag = "--only";
     elseif ($arg_key == "onlyAutomate")
-      $this->only_automate_flag = "-onlyAutomate";
+      $this->only_automate_flag = "--onlyAutomate";
     elseif ($arg_key == "forcelocal")
-      $this->force_local_flag = "-forcelocal";
+      $this->force_local_flag = "--force-local";
     elseif ($arg_key == "localIdentifier")
-      $this->local_identifier_flag = "-localIdentifier $value";
+      $this->local_identifier_flag = "--localIdentifier $value";
     elseif ($arg_key == "proxyHost")
-      $this->proxy_host = "-proxyHost $value";
+      $this->proxy_host = "--proxyHost $value";
     elseif ($arg_key == "proxyPort")
-      $this->proxy_port = "-proxyPort $value";
+      $this->proxy_port = "--proxyPort $value";
     elseif ($arg_key == "proxyUser")
-      $this->proxy_user = "-proxyUser $value";
+      $this->proxy_user = "--proxyUser $value";
     elseif ($arg_key == "proxyPass")
-      $this->proxy_pass = "-proxyPass $value";
+      $this->proxy_pass = "--proxyPass $value";
     elseif ($arg_key == "forceproxy")
-      $this->force_proxy_flag = "-forceproxy";
+      $this->force_proxy_flag = "--forceproxy";
     elseif ($arg_key == "hosts")
       $this->hosts = $value;
     elseif ($arg_key == "f") {

--- a/tests/LocalTest.php
+++ b/tests/LocalTest.php
@@ -37,22 +37,22 @@ class LocalTest extends \PHPUnit_Framework_TestCase {
 
   public function test_set_local_identifier() {
     $this->bs_local->add_args("localIdentifier", "randomString");
-    $this->assertContains('-localIdentifier randomString',$this->bs_local->start_command());
+    $this->assertContains('--localIdentifier randomString',$this->bs_local->start_command());
   }
 
   public function test_enable_only() {
     $this->bs_local->add_args("only");
-    $this->assertContains('-only',$this->bs_local->start_command());
+    $this->assertContains('--only',$this->bs_local->start_command());
   }
 
   public function test_enable_only_automate() {
     $this->bs_local->add_args("onlyAutomate");
-    $this->assertContains('-onlyAutomate', $this->bs_local->start_command()); 
+    $this->assertContains('--onlyAutomate', $this->bs_local->start_command());
   }
 
   public function test_enable_force_local() {
     $this->bs_local->add_args("forcelocal");
-    $this->assertContains('-forcelocal',$this->bs_local->start_command());
+    $this->assertContains('--force-local',$this->bs_local->start_command());
   }
 
   public function test_custom_boolean_argument() {
@@ -74,16 +74,16 @@ class LocalTest extends \PHPUnit_Framework_TestCase {
     $this->bs_local->add_args("proxyPort", 8080);
     $this->bs_local->add_args("proxyUser", "user");
     $this->bs_local->add_args("proxyPass", "pass");
-    $this->assertContains('-proxyHost localhost -proxyPort 8080 -proxyUser user -proxyPass pass',$this->bs_local->start_command());
+    $this->assertContains('--proxyHost localhost --proxyPort 8080 --proxyUser user --proxyPass pass',$this->bs_local->start_command());
   }
 
   public function test_enable_force_proxy() {
-    $this->bs_local->add_args("-forceproxy");
-    $this->assertContains('-forceproxy',$this->bs_local->start_command());
+    $this->bs_local->add_args("forceproxy");
+    $this->assertContains('--forceproxy',$this->bs_local->start_command());
   }
 
   public function test_hosts() {
-    $this->bs_local->add_args("-hosts", "localhost,8080,0");
+    $this->bs_local->add_args("--hosts", "localhost,8080,0");
     $this->assertContains('localhost,8080,0',$this->bs_local->start_command());
   }
 


### PR DESCRIPTION
BrowserStackLocal moved from single dash '-' commandline arguments to '--' doubledash. From BrowserStackLocal --help:

The following command options format will be DEPRECATED. Please use arguments as above!
-version	 Displays the version
-force	 Kill other running Browserstack Local
-only	 Restricts Local Testing access to specified local servers and/or folders
-forcelocal	 Route all traffic via local machine
-onlyAutomate	 Disable Live Testing and Screenshots, just test Automate
-proxyHost HOST	Hostname/IP of proxy, remaining proxy options are ignored if this option is absent
-proxyPort PORT	Port for the proxy, defaults to 3128 when -proxyHost is used
-proxyUser USERNAME	Username for connecting to proxy (Basic Auth Only)
-proxyPass PASSWORD	Password for USERNAME, will be ignored if USERNAME is empty or not specified
-localIdentifier SOME_STRING	If doing simultaneous multiple local testing connections, set this uniquely for different processes
