### PR TITLE
Removing single quotes from logfile on WIN OS

### DIFF
--- a/lib/Local.php
+++ b/lib/Local.php
@@ -141,7 +141,10 @@ class Local {
       $exec = "call";
 
     $user_args = join(' ', $this->user_args);
-    $command = "$exec $this->binary_path -d start -logFile '$this->logfile' $this->folder_flag $this->key $this->folder_path $this->force_local_flag $this->local_identifier_flag $this->only_flag $this->only_automate_flag $this->proxy_host $this->proxy_port $this->proxy_user $this->proxy_pass $this->force_proxy_flag $this->force_flag $this->verbose_flag $this->hosts $user_args";
+    if(strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+      $command = "$exec $this->binary_path -d start -logFile $this->logfile $this->folder_flag $this->key $this->folder_path $this->force_local_flag $this->local_identifier_flag $this->only_flag $this->only_automate_flag $this->proxy_host $this->proxy_port $this->proxy_user $this->proxy_pass $this->force_proxy_flag $this->force_flag $this->verbose_flag $this->hosts $user_args";
+    else
+      $command = "$exec $this->binary_path -d start -logFile '$this->logfile' $this->folder_flag $this->key $this->folder_path $this->force_local_flag $this->local_identifier_flag $this->only_flag $this->only_automate_flag $this->proxy_host $this->proxy_port $this->proxy_user $this->proxy_pass $this->force_proxy_flag $this->force_flag $this->verbose_flag $this->hosts $user_args";
     $command = preg_replace('/\s+/S', " ", $command);
     return $command;
   }


### PR DESCRIPTION
When the start command is run on Windows, the single quotes appear as part of the logfile path or name.

We discovered this when we tried to set the log file argument to `"logfile" => "browserstack.log"` and found that the single quotes appeared as part of the file name.

Trying to set a log file to a different folder path (i.e. `"logfile" => "logs/browserstack.log"`) would cause single quotes to appear in the path itself (which caused BrowserStackLocal.exe to fail all together).

Removing the single quotes from the command string on Windows resolves the issue, but it does mean you can't use spaces in your log file path.