### PR TITLE
LOC 2696 Fix installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you don't already use Composer, you can download the `composer.phar` binary:
 
 Then install the library:
 
-    `php composer.phar require browserstack/local:dev-master`
+    `php composer.phar require browserstack/browserstack-local`
 
 Install all depenedencies:
     `php composer.phar install`


### PR DESCRIPTION
Fixed package name in the installation command, was giving error package not found.

Fixes #18 