### PR TITLE
Pin Semgrep CI image by digest and scope security-events to the upload job (CWE-829)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Don't propose a version the day it is published: a compromised or hijacked release
+    # is usually caught and yanked within a few days. Same reasoning as the digest pin.
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keeps the digest/SHA pins in .github/workflows/ from going stale.
+#
+# NOTE: Dependabot cannot bump the `container: image:` digest in a workflow file — its
+# `docker` ecosystem only parses Dockerfiles, Kubernetes manifests and Helm values
+# (dependabot/dependabot-core#5819), and `github-actions` only covers `uses:` refs.
+# The Semgrep image digest in Semgrep.yml must therefore be refreshed manually (the
+# command is in a comment next to the pin), or by adopting Renovate, which does support
+# workflow container digests.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/Semgrep.yml
+++ b/.github/workflows/Semgrep.yml
@@ -72,12 +72,20 @@ jobs:
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
 
     steps:
+      # Tolerate a missing artifact. If the semgrep job died BEFORE `semgrep ci` ran — a
+      # container-pull failure, or checkout failing — no SARIF was ever written, and this
+      # job should not add a second red pointing at artifact download when the real cause
+      # is upstream. The container job's own failure already tells that story.
+      # (`semgrep ci` exiting 1 on blocking findings is the normal case: the SARIF exists,
+      # the artifact uploads, and the upload below runs as usual.)
       - name: Download SARIF artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: semgrep-sarif
+        continue-on-error: true
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         uses: github/codeql-action/upload-sarif@6c089f53dd51dc3fc7e599c3cb5356453a52ca9e # v2.20.0
         with:
           sarif_file: semgrep.sarif
+        if: hashFiles('semgrep.sarif') != ''

--- a/.github/workflows/Semgrep.yml
+++ b/.github/workflows/Semgrep.yml
@@ -18,16 +18,25 @@ permissions:
 jobs:
   semgrep:
     # User definable name of this GitHub Actions job.
+    # This job runs third-party code (the Semgrep container), so it is granted
+    # `contents: read` only. SARIF upload — which needs `security-events: write` — is
+    # deliberately isolated in the `upload-sarif` job below, so a compromised image
+    # cannot write to the repository's code-scanning dashboard.
     permissions:
       contents: read  # for actions/checkout to fetch code
-      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
-    name: semgrep/ci 
-    # If you are self-hosting, change the following `runs-on` value: 
+    name: semgrep/ci
+    # If you are self-hosting, change the following `runs-on` value:
     runs-on: ubuntu-latest
 
     container:
       # A Docker image with Semgrep installed. Do not change this.
-      image: returntocorp/semgrep:1.166.0
+      # Pinned by immutable digest, not by tag: a tag (even a version tag) can be
+      # re-pointed at new content upstream, which would silently execute unreviewed
+      # third-party code in this runner on the next scheduled run.
+      # Digest below == returntocorp/semgrep:1.166.0 (multi-arch index, pushed 2026-06-11).
+      # To refresh the pin (and update this comment):
+      #   docker manifest inspect returntocorp/semgrep:<version> -v | grep -m1 Digest
+      image: returntocorp/semgrep@sha256:c180f0c93a17b420c0af5006214a29d3c747c5459c732b740191adf657dd0068
     # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')
 
@@ -37,11 +46,38 @@ jobs:
       # Run the "semgrep ci" command on the command line of the docker image.
       - run: semgrep ci --sarif --output=semgrep.sarif
         env:
-            # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable. 
+            # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable.
             SEMGREP_RULES: p/default # more at semgrep.dev/explore
+
+      # Hand the SARIF to the upload job as an artifact. `semgrep ci` exits non-zero when
+      # it has blocking findings, so this must run even on failure.
+      - name: Upload SARIF as a workflow artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: semgrep-sarif
+          path: semgrep.sarif
+          if-no-files-found: error
+        if: always()
+
+  # Separate job so that `security-events: write` is never held by the job running the
+  # third-party Semgrep image. This job runs no third-party code beyond first-party
+  # GitHub actions, all digest-pinned.
+  upload-sarif:
+    name: Upload SARIF to GitHub Advanced Security Dashboard
+    needs: semgrep
+    if: always() && (github.actor != 'dependabot[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
+
+    steps:
+      - name: Download SARIF artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: semgrep-sarif
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         uses: github/codeql-action/upload-sarif@6c089f53dd51dc3fc7e599c3cb5356453a52ca9e # v2.20.0
         with:
           sarif_file: semgrep.sarif
-        if: always()


### PR DESCRIPTION
## What

CI supply-chain hardening for the Semgrep workflow (CWE-829 — *Inclusion of Functionality from Untrusted Control Sphere*).

1. **Pin `returntocorp/semgrep` by immutable digest** instead of the `1.166.0` tag.
2. **Move the SARIF upload into its own job**, so `security-events: write` is no longer held by the job that runs the third-party container.
3. **Add a Dependabot config** for `github-actions` so the action SHA pins don't go stale.

## Why

`.github/workflows/Semgrep.yml` runs a third-party container image on a `0 6 * * *` cron (plus every push/PR to `master`), in a job that has the repository checked out and holds `security-events: write`.

- **A version tag is still mutable.** `1.166.0` was a real improvement over `:latest`, but Docker Hub tags can be re-pointed at new content upstream, and the next scheduled run would pull and execute it with no PR gate. A digest cannot be re-pointed — updating it now requires a reviewable commit, which restores the audit trail.
- **The container did not need `security-events: write`.** Only the SARIF upload does. As written, a compromised image could forge or suppress entries in the repository's code-scanning dashboard. Splitting the jobs means the third-party code runs with `contents: read` and nothing else.

## Changes

**`.github/workflows/Semgrep.yml`**

```diff
-      image: returntocorp/semgrep:1.166.0
+      image: returntocorp/semgrep@sha256:c180f0c93a17b420c0af5006214a29d3c747c5459c732b740191adf657dd0068
```

The digest is the multi-arch OCI index that `returntocorp/semgrep:1.166.0` resolves to today (pushed 2026-06-11) — confirmed independently against `registry-1.docker.io` (`Docker-Content-Digest`) and the Docker Hub v2 tag API. **Same image, so no behavioural change**; pinning the *index* rather than a per-arch manifest keeps the ref architecture-agnostic. The human-readable version and the command to refresh the pin are recorded in a comment next to it.

Job layout:

| Job | Runs third-party code | Permissions |
|---|---|---|
| `semgrep` (unchanged name, so any required check keeps matching) | yes — the Semgrep container | `contents: read` |
| `upload-sarif` (new) | no — first-party actions only | `contents: read`, `security-events: write` |

The SARIF crosses between them as a workflow artifact. Both the artifact upload and the new job use `if: always()`, because `semgrep ci` exits non-zero whenever it has blocking findings — without that, the SARIF would stop reaching the dashboard on exactly the runs that matter.

**`.github/dependabot.yml`** (new) — weekly `github-actions` updates, with a 7-day `cooldown` so a version isn't proposed the day it's published. Note that Dependabot *cannot* bump a workflow `container:` digest: its `docker` ecosystem only parses Dockerfiles, Kubernetes manifests and Helm values ([dependabot-core#5819](https://github.com/dependabot/dependabot-core/issues/5819) is still open), and `github-actions` only covers `uses:` refs. That's why the manual refresh command is in the workflow comment — adopting Renovate, which does support workflow container digests, would automate it.

## Testing

The workflow is exercised by this PR itself — the `pull_request` trigger runs the modified file, so the runs on this PR *are* the test.

| Run | Head | `semgrep/ci` | `upload-sarif` (new) | Overall |
|---|---|---|---|---|
| [31599734585](https://github.com/browserstack/browserstack-local-php/actions/runs/31599734585) | `1fc44b3` | ❌ exit 1 — 1 finding (see below) | ✅ | failure |
| [31599955720](https://github.com/browserstack/browserstack-local-php/actions/runs/31599955720) | `8b08eb9` | ✅ 0 findings | ✅ | ✅ **success** |

Digest pin confirmed from the runner log — `docker pull returntocorp/semgrep@sha256:c180f0c9…` → `semgrep 1.166.0 on python 3.12.13`, i.e. the digest resolves to exactly the version the tag named.

The permission split is confirmed by the *first* run, which is the more informative one: the `semgrep` job failed and the SARIF **still** reached the dashboard, because the artifact upload and the new job both carry `if: always()`. That preserves the one behaviour that mattered about the old upload step.

**The first run's finding was in this PR's own new file, and it was a fair catch.** Semgrep's `p/default` flagged `package_managers.dependabot.dependabot-missing-cooldown` on `.github/dependabot.yml` — a Dependabot with no cooldown proposes a version the instant it's published, which is the same window a hijacked release exploits. Fixed in `8b08eb9`; the re-run is clean.

Also checked locally before pushing: both files parse as YAML; every third-party ref is immutable (digest or full commit SHA, no `@vN` remaining); and asserted programmatically that no job both runs the container and holds `security-events: write`. The image digest was cross-checked against two independent sources (registry `Docker-Content-Digest` header and the Docker Hub v2 tag API).

One thing the green here does **not** mean: on `pull_request`, `semgrep ci` is diff-aware and scanned only the 2 changed files. `master`'s full scan still exits 1 with 5 pre-existing findings (e.g. run [31569942332](https://github.com/browserstack/browserstack-local-php/actions/runs/31569942332)) — untouched by this PR.

## Not in this PR

A `composer.lock` was considered — the repo has none, so `composer install` resolves `phpunit/phpunit: 4.6.*` and its transitives fresh against Packagist on every clone. **It turns out a lockfile cannot be committed here without making things worse.** Composer 2.9 refuses to resolve that constraint at all under its default `block-insecure` audit, and forcing it (`--no-security-blocking`) produces a lock that pins 4 known advisories across 2 packages:

- `phpunit/phpunit 4.6.10` — [CVE-2026-24765](https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-vvj3-c3rp-c85p) (high; fixed in 8.5.52+)
- `symfony/yaml v3.4.47` — CVE-2026-45304, CVE-2026-45305, CVE-2026-45133 (low)
- `phpunit/phpunit-mock-objects 2.3.8` — abandoned

Committing that would require an `audit.ignore` for a high-severity CVE and would pin the vulnerability into the dependency graph. The advisory is in any case already visible without a lockfile — Dependabot alert #1 on the default branch is exactly `GHSA-vvj3-c3rp-c85p`, detected from `composer.json`. The real fix is to move off PHPUnit 4.6 — which means migrating `tests/LocalTest.php` off the `PHPUnit_Framework_TestCase` API — and that belongs in its own PR, separate from CI pinning. Nothing here ships to consumers: both the image and PHPUnit are CI/dev-only (Composer never installs a library's `require-dev` for downstream consumers).

Worth noting for whoever picks that up: no CI job currently runs `composer install` at all. `.travis.yml` still references it, but Travis is no longer wired to this repo — recent commits report no Travis status contexts, only `semgrep/ci` and `Analyze (actions)`.
