### PR TITLE
LOC-7291: download darwin-arm64 binary on Apple Silicon

### DIFF
--- a/lib/LocalBinary.php
+++ b/lib/LocalBinary.php
@@ -69,7 +69,12 @@ class LocalBinary {
   }
 
   public function download_binary($path) {
-    $url = $this->platform_url();
+    $urls = array($this->platform_url());
+    // If the arm64 binary is not published to the legacy bucket yet, fall
+    // back to the x64 binary, which still works on Apple Silicon via
+    // Rosetta 2 — releasing must not turn a working download into a 404.
+    if (substr($urls[0], -13) === '-darwin-arm64')
+      $urls[] = str_replace('-darwin-arm64', '-darwin-x64', $urls[0]);
     if (!file_exists($path))
       mkdir($path, 0777, true);
 
@@ -79,18 +84,29 @@ class LocalBinary {
       $dest_binary_name = $dest_binary_name. ".exe";
     }
     $dest_binary_path = $path. '/'. $dest_binary_name;
-    $file = fopen($dest_binary_path , "w+");
-    $ch = curl_init("");
-    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-    curl_setopt($ch, CURLOPT_URL, $url);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_FILE, $file);
-    $data = curl_exec ($ch);
-    curl_close ($ch);
-    
-    fclose($file);
-    chmod($dest_binary_path, 0755);
-    return $dest_binary_path;
+    foreach ($urls as $url) {
+      $file = fopen($dest_binary_path , "w+");
+      $ch = curl_init("");
+      curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+      curl_setopt($ch, CURLOPT_URL, $url);
+      curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+      curl_setopt($ch, CURLOPT_FILE, $file);
+      // Fail on HTTP >= 400 instead of writing the error body to disk —
+      // a saved error body would satisfy the file_exists() check in
+      // binary_path() and stick until the user deletes it by hand.
+      curl_setopt($ch, CURLOPT_FAILONERROR, true);
+      $data = curl_exec ($ch);
+      curl_close ($ch);
+
+      fclose($file);
+      if ($data !== false) {
+        chmod($dest_binary_path, 0755);
+        return $dest_binary_path;
+      }
+      // remove the empty/partial file so the next attempt (or next run) retries
+      unlink($dest_binary_path);
+    }
+    throw new LocalException("Failed to download BrowserStackLocal binary from: " . implode(", ", $urls));
   }
 
   private function get_available_dirs() {

--- a/lib/LocalBinary.php
+++ b/lib/LocalBinary.php
@@ -53,8 +53,11 @@ class LocalBinary {
   }
 
   private function platform_url(){
-    if (PHP_OS == "Darwin")
+    if (PHP_OS == "Darwin") {
+      if (in_array(php_uname('m'), array('arm64', 'aarch64')))
+        return 'https://s3.amazonaws.com/browserStack/browserstack-local/BrowserStackLocal-darwin-arm64';
       return 'https://s3.amazonaws.com/browserStack/browserstack-local/BrowserStackLocal-darwin-x64';
+    }
     else if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
       return 'https://s3.amazonaws.com/browserStack/browserstack-local/BrowserStackLocal.exe';
     if ((strtoupper(PHP_OS)) == "LINUX") {


### PR DESCRIPTION
## What

On macOS, the binding now downloads `BrowserStackLocal-darwin-arm64` when the runtime reports arm64; x64 runtimes (including x64-under-Rosetta) keep `BrowserStackLocal-darwin-x64`, preserving current behavior.

Detection: php_uname('m') in arm64/aarch64.

## Why

The Local binary now ships a native Apple Silicon build (browserstack/browserStackTunnel#980). macOS 27 (fall 2026) removes Rosetta 2, so arm64 Macs need the native binary.

## Testing

php -l clean; platform_url() returns the arm64 URL on an Apple Silicon Mac.

## ⚠ Release ordering

Do not release this before:
- browserstack/browserStackTunnel#980 is merged and a master build has published `binaries/master/BrowserStackLocal-darwin-arm64.zip` (public ACL line is already in the Jenkins job) — otherwise arm64 Macs get download failures.
- This binding downloads from the legacy S3 path (s3.amazonaws.com/browserStack/browserstack-local/). Per review, the download now verifies the HTTP result and **falls back to the x64 binary** (works via Rosetta 2) when the arm64 object is missing, and never leaves an HTTP error body behind as the "installed" binary — so release ordering is no longer a correctness gate here. Publishing the darwin-arm64 object to that bucket is still wanted so arm64 users get the native binary.

## Related Jira

LOC-7291 / epic LOC-7287 (LOC-7285 = binary PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
